### PR TITLE
chore: bumps docker-cli-js v2.5.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -184,19 +184,13 @@
 			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
 		},
 		"cli-table-2-json": {
-			"version": "1.0.12",
-			"resolved": "https://registry.npmjs.org/cli-table-2-json/-/cli-table-2-json-1.0.12.tgz",
-			"integrity": "sha512-w4K5AGCI6CRsdUJAayiMEKusCMEK8TcZIbhHLLNJJdS6iu5P2dHbjf6EcmWm61fxfKLlmtwrtpiKT9SJJ+b7Sw==",
+			"version": "1.0.13",
+			"resolved": "https://registry.npmjs.org/cli-table-2-json/-/cli-table-2-json-1.0.13.tgz",
+			"integrity": "sha512-CpUj9dubfuIZSEezwUPycAJqM2dlATyyRUyBkfGeK2KNfrqK3XrdaBohMt0XlkEvsZyDfUEmPWCNvUO+a/7Wsw==",
 			"requires": {
 				"@types/blue-tape": "^0.1.30",
-				"@types/lodash": "4.14.119"
-			},
-			"dependencies": {
-				"lodash": {
-					"version": "4.17.15",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-					"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
-				}
+				"@types/lodash": "4.14.119",
+				"lodash": "^4.17.15"
 			}
 		},
 		"cliui": {
@@ -347,28 +341,22 @@
 			}
 		},
 		"docker-cli-js": {
-			"version": "2.5.2",
-			"resolved": "https://registry.npmjs.org/docker-cli-js/-/docker-cli-js-2.5.2.tgz",
-			"integrity": "sha512-uoDNhZ5mpCLHtDGzX7tNg2FQVFt4Kf4PfdxiXAHqx4iBXQNEHtIkFLHuVP7S+x/MoxUqjgR/S3vyCtwo/pPDbw==",
+			"version": "2.5.3",
+			"resolved": "https://registry.npmjs.org/docker-cli-js/-/docker-cli-js-2.5.3.tgz",
+			"integrity": "sha512-23MxzriL0xekQkdd/xjG+xYU2HnRU2kqZN9d5LToYqXUzKkVJ/W89HRr0oXNVgPOG/C47b39lFQd96Q0inwd8w==",
 			"requires": {
-				"cli-table-2-json": "1.0.12",
-				"dockermachine-cli-js": "3.0.4",
+				"cli-table-2-json": "1.0.13",
+				"dockermachine-cli-js": "3.0.5",
+				"lodash": "^4.17.15",
 				"nodeify-ts": "1.0.6"
-			},
-			"dependencies": {
-				"lodash": {
-					"version": "4.17.15",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-					"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
-				}
 			}
 		},
 		"dockermachine-cli-js": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/dockermachine-cli-js/-/dockermachine-cli-js-3.0.4.tgz",
-			"integrity": "sha512-iQYkVp/fI1MZ0I9QDWOHfv/weTJeHEN1Bla8TtONjJBbUAp5QPNM3r9UL5bUNvpsHR7YzVMEd6HersBq7pHogA==",
+			"version": "3.0.5",
+			"resolved": "https://registry.npmjs.org/dockermachine-cli-js/-/dockermachine-cli-js-3.0.5.tgz",
+			"integrity": "sha512-oV9RRKGvWrvsGl8JW9TWKpjBJVGxn/1qMvhqwPJiOPfRES0+lrq/Q8Wzixb6qinuXPVBhlWqhXb/Oxrh6Vuf/g==",
 			"requires": {
-				"cli-table-2-json": "1.0.12",
+				"cli-table-2-json": "1.0.13",
 				"nodeify-ts": "1.0.6"
 			}
 		},
@@ -710,6 +698,11 @@
 				"p-locate": "^3.0.0",
 				"path-exists": "^3.0.0"
 			}
+		},
+		"lodash": {
+			"version": "4.17.15",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+			"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
 		},
 		"logform": {
 			"version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
 	},
 	"dependencies": {
 		"aws-sdk": "^2.502.0",
-		"docker-cli-js": "2.5.2",
+		"docker-cli-js": "2.5.3",
 		"express": "^4.17.1",
 		"express-rate-limit": "^5.0.0",
 		"ip": "^1.1.5",


### PR DESCRIPTION
Bumps `docker-cli-js` to the latest release